### PR TITLE
Add go.sum File Support

### DIFF
--- a/Gosum.sublime-syntax
+++ b/Gosum.sublime-syntax
@@ -6,6 +6,7 @@
 
 file_extensions: [sum]
 scope: source.gosum
+hidden: true
 
 variables:
   ident: (?:[^\s/()]|/(?!/))+

--- a/Gosum.sublime-syntax
+++ b/Gosum.sublime-syntax
@@ -1,0 +1,55 @@
+%YAML 1.2
+---
+# http://www.sublimetext.com/docs/3/syntax.html
+
+# https://github.com/golang/go/tree/master/src/cmd/go/internal/modfetch
+
+file_extensions: [sum]
+scope: source.gosum
+
+variables:
+  ident: (?:[^\s/()]|/(?!/))+
+  semver_string: v\d+\.\d+\.\d+
+  gomod_path: \/go\.mod
+  algorithm: h\d
+  checksum: \w|\/|\+
+  version_checksum: \-\d{14}\-[a-f0-9]{12}
+
+contexts:
+  main:
+    - include: match-root
+
+
+  # The form of each line in go.sum is three fields:
+  #
+  #     <module> <version>[/go.mod] <hash>
+  #
+  # Each known module version results in two lines in the go.sum file.
+  # The first line gives the hash of the module version's file tree.
+  # The second line appends "/go.mod" to the version and gives the hash
+  # of only the module version's (possibly synthesized) go.mod file.
+  #
+  # The hash begins with an algorithm prefix of the form "h<N>:".
+  match-root:
+    - match: |
+        (?x)
+        ^
+        ({{ident}})\s+
+        ({{semver_string}})
+        ({{version_checksum}})?
+        ({{gomod_path}})?\s+
+        ({{algorithm}})
+        (\:)
+        (({{checksum}})*)
+        (=)
+        \s*
+        $
+      captures:
+        1: variable.gosum
+        2: string.version.gosum
+        3: string.gosum
+        4: string.gosum
+        5: entity.name.label.gosum
+        6: punctuation.separator.gosum
+        7: constant.language.gosum
+        9: punctuation.separator.gosum

--- a/readme.md
+++ b/readme.md
@@ -1,6 +1,6 @@
 ## Overview
 
-Syntax definition for `go.mod` files for Sublime Text. `go.mod` is a manifest file for Go packages; read about it on https://golang.org/cmd/go/.
+Syntax definition for `go.mod` and `go.sum` files for Sublime Text. `go.mod` is a manifest file for Go packages; read about it on https://golang.org/cmd/go/.
 
 Related: since you're using Sublime Text with Go, consider a better Go syntax: https://github.com/Mitranim/sublime-gox.
 
@@ -12,7 +12,7 @@ Alternatively, clone this repository into Sublime's Packages folder. On MacOS, t
 
 ## Usage
 
-`*.mod` files should be automatically highlighted. Enjoy!
+`*.mod` and `*.sum` files should be automatically highlighted. Enjoy!
 
 ## Misc
 

--- a/syntax_test_gosum.sum
+++ b/syntax_test_gosum.sum
@@ -1,0 +1,49 @@
+// SYNTAX TEST "Gosum.sublime-syntax"
+
+github.com/DATA-DOG/go-sqlmock v1.3.3 h1:CWUqKXe0s8A2z6qCgkP4Kru7wC11YoAnoupUKFDnH08=
+// <- variable.gosum
+ // <- variable.gosum
+  // <- variable.gosum
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^ variable.gosum
+//                             ^^^^^^ string.version.gosum
+//                                    ^^ entity.name.label.gosum
+//                                      ^ punctuation.separator.gosum
+//                                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.language.gosum
+//                                                                                  ^ punctuation.separator.gosum
+
+github.com/DATA-DOG/go-sqlmock v1.3.3/go.mod h1:f/Ixk793poVmq4qj/V1dPUg2JEAKC73Q5eFN3EC/SaM=
+// <- variable.gosum
+ // <- variable.gosum
+  // <- variable.gosum
+// ^^^^^^^^^^^^^^^^^^^^^^^^^^^ variable.gosum
+//                             ^^^^^^ string.version.gosum
+//                                   ^^^^^^^ string.gosum
+//                                           ^^ entity.name.label.gosum
+//                                             ^ punctuation.separator.gosum
+//                                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.language.gosum
+//                                                                                         ^ punctuation.separator.gosum
+
+github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af h1:pmfjZENx5imkbgOkpRUYLnmbU7UEFbjtDA2hxJ1ichM=
+// <- variable.gosum
+ // <- variable.gosum
+  // <- variable.gosum
+//^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ variable.gosum
+//                              ^^^^^^ string.version.gosum
+//                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.gosum
+//                                                                 ^^ entity.name.label.gosum
+//                                                                   ^ punctuation.separator.gosum
+//                                                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.language.gosum
+//                                                                                                               ^ punctuation.separator.gosum
+
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+// <- variable.gosum
+ // <- variable.gosum
+  // <- variable.gosum
+// ^^^^^^^^^^^^^^ variable.gosum
+//                ^^^^^^ string.version.gosum
+//                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ string.gosum
+//                                                          ^^ entity.name.label.gosum
+//                                                            ^ punctuation.separator.gosum
+//                                                             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ constant.language.gosum
+//                                                                                                        ^ punctuation.separator.gosum
+ 


### PR DESCRIPTION
Add support for highlighting `go.sum` files. Also, inadvertently, allows [AFileIcon](https://github.com/SublimeText/AFileIcon) to give `go.sum` files a custom icon.

<img width="1565" alt="Screen Shot 2019-10-01 at 9 57 30 PM" src="https://user-images.githubusercontent.com/7366232/66015021-9ce52100-e496-11e9-848c-5eedf1fa634e.png">
